### PR TITLE
Update help with units for duration

### DIFF
--- a/pi2c/__main__.py
+++ b/pi2c/__main__.py
@@ -44,7 +44,7 @@ def get_args():
                         action='store',
                         default=600,
                         type=int,
-                        help='Duration for downtime')
+                        help='Duration for downtime, in seconds (default: 600s)')
 
     parser.add_argument('-a', '--author',
                         action='store',


### PR DESCRIPTION
I got bit last night while using pi2c in thinking that duration was in
minutes instead of seconds.  This updates the --help output to clarify
that point.

Now looks like:

```
  -d DURATION, --duration DURATION
                        Duration for downtime, in seconds (default: 600s)
```