### PR TITLE
Match on host.display_name instead of host.name

### DIFF
--- a/pi2c/client.py
+++ b/pi2c/client.py
@@ -21,7 +21,7 @@ class Client:
         """
         Return a filter
         """
-        return 'match("{}", host.name)'.format(hostname)
+        return 'match("{}", host.display_name)'.format(hostname)
 
     def service_filter(self, servicename, hostname=None):
         """
@@ -29,7 +29,7 @@ class Client:
         """
         service_part = 'match("{}", service.name)'.format(servicename)
         if hostname:
-            host_part = 'match("{}", host.name)'.format(hostname)
+            host_part = 'match("{}", host.display_name)'.format(hostname)
             service_part = host_part + ' && ' + service_part
         return service_part
 


### PR DESCRIPTION
In the Puppet Icinga installation host names correspond to certname, and the display names correspond to the actual host names. Thus, the display name is more useful for us.

@mattkirby, would this be better if it were a flag? If so, should it default to host name, or host display name?